### PR TITLE
[BugFix] fix prompt selection bug

### DIFF
--- a/fuel/exec/exec_template.py
+++ b/fuel/exec/exec_template.py
@@ -6,20 +6,18 @@ from ..exec.render_code import get_rendered_code
 from ..exec.utils import is_equal_tensor
 from ..feedback.feedback import FeedBack
 from ..utils.Filer import File
-from ..utils.util import eliminate_imports
+from ..utils.util import extract_model_code
 
 
 def exec_template(
     code,
-) -> None:  # TODO@SHAOYU: Add support for diff testing on different devices
+) -> str:  # TODO@SHAOYU: Add support for diff testing on different devices
     # Before execution, the code is unknown.
     FeedBack.feedback_code = OracleType.UNKNOWN
     FeedBack.has_bug = FeedBack.has_exception = False
     try:
         File.rendered_code = get_rendered_code(FeedBack.lib, code)
-        File.eliminated_code = eliminate_imports(
-            File.rendered_code
-        )  # FIXME@SHAOYU: It seems that we don't use eliminated code. If it is legacy, we should delete it.
+        extracted_model_code = extract_model_code(File.rendered_code)
     except Exception as e:
         exception = str(e)
         # situation1: If there is a syntax error in the code, it is deemed an invalid model.
@@ -36,7 +34,7 @@ def exec_template(
         logger.error("<--------------- Syntax error in the code. --------------->")
         FeedBack.feedback_code = OracleType.SYNTAX_ERROR
         File.write_file(File.fail_file, File.cur_filename)
-        return
+        return code
 
     File.write_file(File.tmp_py, File.rendered_code, "w")
     base_code, target_code = DiffTesting.testing()
@@ -206,3 +204,4 @@ def exec_template(
             f"\t\t{exception}",
             "w",
         )
+    return extracted_model_code

--- a/fuel/exec/exec_template.py
+++ b/fuel/exec/exec_template.py
@@ -50,10 +50,13 @@ def exec_template(
     if base_code == OracleType.BASE_SUCCESS:
         if target_code == OracleType.TRANSFER_EXCEPTION:
             final_code = OracleType.TRANSFER_EXCEPTION
+            File.write_file(
+                File.validate_file,
+                f"<-- WARNING: {FeedBack.base_version}:SUCCESS, {FeedBack.target_version}:TRANSFER_ERROR  -->",
+            )
 
         elif target_code == OracleType.TARGET_EXCEPTION:
             final_code = OracleType.TARGET_EXCEPTION
-            FeedBack.has_exception = True
             File.write_file(
                 File.validate_file,
                 f"<-- WARNING: {FeedBack.base_version}:SUCCESS, {FeedBack.target_version}:ERROR  -->",
@@ -115,7 +118,12 @@ def exec_template(
                 File.success_file, f"Round {FeedBack.cur_round}:{File.cur_filename}"
             )
 
-        case OracleType.INCON | OracleType.TARGET_EXCEPTION | OracleType.MISALIGN:
+        case (
+            OracleType.INCON
+            | OracleType.TRANSFER_EXCEPTION
+            | OracleType.TARGET_EXCEPTION
+            | OracleType.MISALIGN
+        ):
             File.write_file(
                 File.fail_file, f"Round {FeedBack.cur_round}:{File.cur_filename}"
             )
@@ -124,7 +132,7 @@ def exec_template(
             )
             FeedBack.has_bug = True
 
-        case OracleType.BASE_EXCEPTION | OracleType.TRANSFER_EXCEPTION:
+        case OracleType.BASE_EXCEPTION:
             File.write_file(
                 File.fail_file, f"Round {FeedBack.cur_round}:{File.cur_filename}"
             )
@@ -134,6 +142,7 @@ def exec_template(
     # Exception error file init
     if FeedBack.feedback_code in (
         OracleType.INCON,
+        OracleType.TRANSFER_EXCEPTION,
         OracleType.TARGET_EXCEPTION,
         OracleType.MISALIGN,
     ):
@@ -172,6 +181,20 @@ def exec_template(
             File.err_file,
             f"\nThe results of model execution on {FeedBack.base_version} and {FeedBack.target_version} produced numerical inconsistencies.\n"
             f"\tThe maximum difference between the corresponding elements of different output tensors is {max_diff}\n",
+            "w",
+        )
+
+    elif FeedBack.feedback_code == OracleType.TRANSFER_EXCEPTION:
+        File.write_file(
+            File.bug_report,
+            f"--------------【The code executes successfully in {FeedBack.base_version} mode but fails while preparing {FeedBack.target_version} mode.】--------------\n",
+        )
+
+        File.write_file(
+            File.err_file,
+            f"The code throws an exception during execution.\n"
+            f"\tThe code executes successfully in {FeedBack.base_version} mode but fails while preparing {FeedBack.target_version} mode.\n"
+            f"\t\t{exception}",
             "w",
         )
 

--- a/fuel/fuzz.py
+++ b/fuel/fuzz.py
@@ -190,7 +190,7 @@ def run_fuzz(
 
     while FeedBack.cur_round < max_round:
         # Execute single round test
-        file_path = fuzzing_core.execute_single_round(
+        file_path, extracted_model_code = fuzzing_core.execute_single_round(
             feedback_data, heuristic_instance, op_nums, diff_type
         )
 
@@ -198,7 +198,7 @@ def run_fuzz(
         flag = fuzzing_core.handle_execution_results(file_path, flag)
 
         # Process feedback
-        feedback_data = fuzzing_core.process_feedback(file_path)
+        feedback_data = fuzzing_core.process_feedback(file_path, extracted_model_code)
 
         # Increment round
         FeedBack.cur_round += 1

--- a/fuel/utils/Filer.py
+++ b/fuel/utils/Filer.py
@@ -22,7 +22,6 @@ class _SimpleFileManager:
         # Runtime state variables
         self.cur_filename = ""
         self.rendered_code = ""
-        self.eliminated_code = ""
 
         # Initialize directories and file paths
         self._setup_directories()
@@ -168,7 +167,7 @@ class FileMeta(type):
         """Set attribute on instance if it is an instance attribute."""
         if hasattr(cls, "_instance") and cls._instance and hasattr(cls._instance, name):
             # For runtime state attributes, set on instance
-            if name in ["cur_filename", "rendered_code", "eliminated_code"]:
+            if name in ["cur_filename", "rendered_code"]:
                 setattr(cls._instance, name, value)
                 return
         super().__setattr__(name, value)

--- a/fuel/utils/fuzzing_core.py
+++ b/fuel/utils/fuzzing_core.py
@@ -101,20 +101,9 @@ class FuzzingCore:
         FeedBack.new_ops = []
 
         if FeedBack.has_bug:
-            if flag:
-                FeedBack.fix_total_times += 1
-                File.write_file(
-                    File.fix_file,
-                    f"<------ No.{FeedBack.fix_total_times}:{File.cur_filename} ------>",
-                )
-                flag = False
-                FeedBack.new_ops = FeedBack.cur_ops
-            else:
-                # Fix successful
-                File.write_file(
-                    File.fix_file, f"| Fix Successfully:{File.cur_filename}"
-                )
-                FeedBack.fix_success_times += 1
+            # Oracle violations should enter bug analysis directly instead of
+            # participating in the invalid-model repair loop.
+            if not flag:
                 flag = True
 
         elif FeedBack.has_exception:

--- a/fuel/utils/fuzzing_core.py
+++ b/fuel/utils/fuzzing_core.py
@@ -74,11 +74,12 @@ class FuzzingCore:
             prompt=gen_prompt,
         )
 
+        previous_code = feedback_data.get("feedback", {}).get("code", "")
         # Write analysis logs
         File.write_file(
             File.als_file,
             f"""-------------Current analysis file is {File.cur_filename} -------------
-                                                              \rCode follows up: \n{File.eliminated_code}
+                                                              \rCode follows up: \n{previous_code}
                                                               \rAnalysis text follows up:\n{als_res}
                                                               \n""",
         )
@@ -90,9 +91,9 @@ class FuzzingCore:
 
         # Execute differential testing
         DiffTesting.diff_type = diff_type
-        exec_template(code)
+        extracted_model_code = exec_template(code)
 
-        return file_path
+        return file_path, extracted_model_code
 
     def handle_execution_results(self, file_path, flag):
         """Handle execution results and fix logic"""
@@ -142,7 +143,7 @@ class FuzzingCore:
 
         return flag
 
-    def process_feedback(self, file_path):
+    def process_feedback(self, file_path, extracted_model_code):
         """Process feedback and coverage based on execution status
 
         Handles different execution statuses:
@@ -151,7 +152,7 @@ class FuzzingCore:
         - EXCEPTION: Record invalid test case (exception in both backends)
         """
         logger.info(f"<-- After exec, current filename is: {file_path} -->")
-        File.write_file(file_path, File.eliminated_code)
+        File.write_file(file_path, extracted_model_code)
 
         # Get execution status
         status, message = FeedBack.get_status()
@@ -169,7 +170,7 @@ class FuzzingCore:
                 FeedBack.feedback_code = OracleType.SUCCESS_WITH_NEWCOV
 
             feedback_data = {
-                "code": File.eliminated_code,
+                "code": extracted_model_code,
                 "coverage": feedbk,
             }
 
@@ -198,7 +199,7 @@ class FuzzingCore:
             # Oracle violation - potential framework bug
             feedbk = message
             feedback_data = {
-                "code": File.eliminated_code,
+                "code": extracted_model_code,
                 "bug": feedbk,
             }
             logger.warning("Oracle violation detected - treating as potential bug")
@@ -218,7 +219,7 @@ class FuzzingCore:
             # Invalid test case - exception in both backends
             feedbk = message
             feedback_data = {
-                "code": File.eliminated_code,
+                "code": extracted_model_code,
                 "exception": feedbk,
             }
             logger.info("Exception in both backends - treating as invalid test")
@@ -234,7 +235,6 @@ class FuzzingCore:
                 logger.success("execute successfully\n")
                 # logger.exception(f"The feedback follows up: \n{feedbk}\n")
 
-        # logger.debug(f"The code follows up: \n\n{File.eliminated_code}\n")
         logger.info(
             f"fix total: {FeedBack.fix_success_times + FeedBack.fix_fail_times},success:{FeedBack.fix_success_times}\n"
         )

--- a/fuel/utils/util.py
+++ b/fuel/utils/util.py
@@ -33,7 +33,7 @@ def extra_code_from_text(input_text):
         return input_text
 
 
-def eliminate_imports(code: str) -> str:
+def extract_model_code(code: str) -> str:
     # print(f"[debug] the code is \n{code}")
     match = re.search(r"class\s+\w+\s*\(.*?inputs\s*=\s*\[.*?\]", code, re.DOTALL)
     # print(f"[debug] after re match , the code is \n{match.group(0)}")


### PR DESCRIPTION
commit-1: refactor the global var `File.eliminated_code` into return var, which is more clear
commit-2: Previously, if target_code triggers an exception, we incorrectly set **`FeedBack.has_exception = True`**, which can cause the subsequent prompt selection to mistakenly use the self-repair prompt template.

<img width="874" height="143" alt="image" src="https://github.com/user-attachments/assets/cceab4df-d9a9-4201-85e9-573c02e75b95" />
